### PR TITLE
Update ff.c to get rid of the compile-warning

### DIFF
--- a/FatFs_SPI/ff14a/source/ff.c
+++ b/FatFs_SPI/ff14a/source/ff.c
@@ -2044,7 +2044,7 @@ static void gen_numname (
 		if (c > '9') c += 7;
 		ns[i--] = c;
 		seq /= 16;
-	} while (seq);
+	} while (i && seq);
 	ns[i] = '~';
 
 	/* Append the number to the SFN body */


### PR DESCRIPTION
Hi Derek,
in the project https://github.com/Isysxp/Pico_1140 we found while comparing ff.c from ff14a and ff15 (ff15 is now the actual one on github at https://github.com/carlk3/no-OS-FatFS-SD-SPI-RPi-Pico that this small change prevents the compile-warning for ff.c If you want to use ff14a then this change may be good for you (its like a backport correction from ff15) or yu can try to use the newer ff15. At the project https://github.com/Isysxp/Pico_1140 we will test the ff15 in the next days.